### PR TITLE
Correct painting title and year

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -25,8 +25,8 @@
 			and on digital scans from<br/>
 			<a href="https://books.google.com/books?id=qVcVAAAAYAAJ">Google Books</a>.</p>
 			<p>The cover page is adapted from<br/>
-			<i epub:type="se:name.visual-art.painting">Comtesse de La Tour-Maubourg</i>,<br/>
-			a painting completed in 1841 by<br/>
+			<i epub:type="se:name.visual-art.painting">Portrait of Catherine Worlée, Princesse de Talleyrand-Périgord</i>,<br/>
+			a painting completed circa 1804 by<br/>
 			<a href="https://en.wikipedia.org/wiki/Fran%C3%A7ois_G%C3%A9rard">François Gérard</a>.<br/>
 			The cover and title pages feature the<br/>
 			<b epub:type="se:name.visual-art.typeface">League Spartan</b> and <b epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</b><br/>


### PR DESCRIPTION
Artist was updated in d4cd4e7da34818e5cc333659163f0804e73bb4e4, but not the title and year
